### PR TITLE
derive resourcing from helm values

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,0 +1,16 @@
+name: Yaml Lint
+on: [pull_request]
+jobs:
+  lintAllTheThings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Prep helm
+      uses: WyriHaximus/github-action-helm3@v2
+      with:
+        exec: helm template --output-dir test-output/ .
+    - name: yaml-lint
+      uses: ibiqlik/action-yamllint@v1
+      with:
+        file_or_dir: test-output
+        config_file: .yamllint.yml

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -67,9 +67,9 @@ spec:
           # You may want to configure resources depending on hardware:
           resources:
             limits:
-              cpu: 1000m
-              memory: 2Gi
+              cpu: {{ .Values.resources.cpu | default "1" }}
+              memory: {{ .Values.resources.memory | default "2Gi" }}
             requests:
-              cpu: 1000m
-              memory: 2Gi
+              cpu: {{ .Values.resources.cpu | default "1" }}
+              memory: {{ .Values.resources.memory | default "2Gi" }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,3 +8,5 @@ image:
 
 honeycomb:
   dataset: production
+
+resources: {}


### PR DESCRIPTION
moves the collector resources to pull from `.Values.resources` and defaults them to the originally set values - this provides the ability for the deployment to inherit it's resources from upstream (e.g. an argo app). Once this capability is in place I can set overrides based on cluster-size which will fix the current resourcing constraints getting hit in FR clusters.

lint pipeline comes for free <3 