### PR TITLE
SRE-142: Scrape Collector metrics and send to Honeycomb

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -68,5 +68,5 @@ data:
           exporters: [otlp]
         metrics:
           receivers: [prometheus]
-          processors: []
+          processors: [resource]
           exporters: [otlp/metrics]


### PR DESCRIPTION
Honeycomb enabled metrics for us! I tested this with a local collector instance, you can see the data arriving here: https://ui.honeycomb.io/equinix/datasets/collector-metrics/result/coEq8cRnd1d/a/5N7ocuvRuAp/Example-collector-metrics-query

I also tested in the boots namespace in am6: https://ui.honeycomb.io/equinix/datasets/collector-metrics/result/4zJM8tqrNi7