### PR TITLE
SRE-100: Update batch timeout to reduce ingest latency

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -20,7 +20,7 @@ data:
                 - targets: ["127.0.0.1:8888"]
     processors:
       batch:
-        timeout: 1s
+        timeout: 200ms
       memory_limiter:
         limit_mib: "400"
         spike_limit_mib: "100"


### PR DESCRIPTION
Tested out 1s and 200ms on the collector for cacher in LA4. [Query results](https://ui.honeycomb.io/equinix/datasets/production/result/CLUecu2vntr/a/Eg9wjZftLGn/Canary-cacher-in-LA4-Reducing-collector-batch-timeout).

200ms is the default so I think I want to go with that for most app namespaces. We can try out different values for API specifically if it needs more TLC.