### PR TITLE
Update executable name

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: opentelemetry-collector
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command:
-            - "/otelcontribcol"
+            - "/otelcol-contrib"
             - "--config=/conf/opentelemetry-collector-config.yaml"
           env:
             - name: HONEYCOMB_TEAM


### PR DESCRIPTION
I opened this PR against #16, which updates the Collector version from v0.38.0 to v0.53.0. Somewhere in all those versions the OTel maintainers renamed the executable from `/otelcontribcol` to `/otelcol-contrib` (which I agree is a better name), so we need to update our deployment manifest to reflect that alongside the version update.

Originally #16 blew up on the "missing" binary. I tested this branch with both changes together and it worked great.