### PR TITLE
Add service.group field

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -42,6 +42,8 @@ data:
         - key: metal.facility
           value: {{ .Values.clusterInfo.facility }}
           action: insert
+        - key: service.group
+          value: "equinix-metal"
     exporters:
       otlp:
         endpoint: "api.honeycomb.io:443"


### PR DESCRIPTION
In the new Honeycomb Environments & Services setup, it's often desirable to query across many services within an environment. The new service.group field will allow us to group multiple services and query against them. I want to do this for Metal services along with other relevant groups like Access Management, Fabric, Identity, and CRH.