### PR TITLE
Fix service.group field

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -44,6 +44,7 @@ data:
           action: insert
         - key: service.group
           value: "equinix-metal"
+          action: insert
     exporters:
       otlp:
         endpoint: "api.honeycomb.io:443"


### PR DESCRIPTION
This is what I get for hand-editing yaml in the GitHub UI. Tested this version and it worked this time instead of doing a CrashLoopBackoff