### PR TITLE
Add spanmetrics processor and prometheus exporter

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: otlp-grpc
               containerPort: 4317
               protocol: TCP
-            - name: prometheus-exporter
+            - name: prometheus-exp
               containerPort: 8889
               protocol: TCP
           volumeMounts:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - name: otlp-grpc
               containerPort: 4317
               protocol: TCP
+            - name: prometheus-exporter
+              containerPort: 8889
+              protocol: TCP
           volumeMounts:
             - name: opentelemetry-collector-config
               mountPath: /conf

--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -18,6 +18,12 @@ data:
               scrape_interval: 15s
               static_configs:
                 - targets: ["127.0.0.1:8888"]
+      # Dummy receiver that's never used, because a pipeline is required to have one.
+      otlp/spanmetrics:
+        protocols:
+          grpc:
+            endpoint: "localhost:12345"
+
     processors:
       batch:
         timeout: 200ms
@@ -45,6 +51,10 @@ data:
         - key: service.group
           value: "equinix-metal"
           action: insert
+    spanmetrics:
+      metrics_exporter: prometheus
+      # MASSIVE TODO
+
     exporters:
       otlp:
         endpoint: "api.honeycomb.io:443"
@@ -56,6 +66,9 @@ data:
           "x-honeycomb-team": "${HONEYCOMB_ENV_API_KEY}"
           # dataset is required for metrics data
           "x-honeycomb-dataset": "collector-metrics"
+      prometheus:
+        endpoint: 0.0.0.0:8889
+
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -67,9 +80,12 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, resource, batch, spanmetrics]
           exporters: [otlp]
         metrics:
           receivers: [prometheus]
           processors: [resource]
-          exporters: [otlp/metrics]
+          exporters: [otlp/metrics,prometheus]
+        metrics/spanmetrics:
+          receivers: [otlp/spanmetrics]
+          exporters: [prometheus]

--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -52,7 +52,6 @@ data:
           value: "equinix-metal"
           action: insert
       spanmetrics:
-        # MASSIVE TODO
         metrics_exporter: prometheus
 
     exporters:

--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -51,9 +51,9 @@ data:
         - key: service.group
           value: "equinix-metal"
           action: insert
-    spanmetrics:
-      metrics_exporter: prometheus
-      # MASSIVE TODO
+      spanmetrics:
+        # MASSIVE TODO
+        metrics_exporter: prometheus
 
     exporters:
       otlp:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,3 +24,7 @@ spec:
     port: 8888
     protocol: TCP
     targetPort: 8888
+  - name: prometheus-exporter
+    port: 8889
+    protocol: TCP
+    targetPort: 8889


### PR DESCRIPTION
This is a first pass at adding the spanmetrics processor for deriving RED metrics from traced applications. 