### PR TITLE
Allow chart users to override default memory limits

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -28,9 +28,9 @@ data:
       batch:
         timeout: 200ms
       memory_limiter:
-        limit_mib: "400"
-        spike_limit_mib: "100"
-        check_interval: "5s"
+        limit_mib: {{ .Values.otel_collector.memory_limiter.limit_mib }}
+        spike_limit_mib: {{ .Values.otel_collector.memory_limiter.spike_limit_mib }}
+        check_interval: {{ .Values.otel_collector.memory_limiter.check_interval }}
       resource:
         attributes:
         - key: k8s.cluster.endpoint

--- a/values.yaml
+++ b/values.yaml
@@ -7,3 +7,10 @@ image:
   pullPolicy: IfNotPresent
 
 resources: {}
+
+
+otel_collector:
+  memory_limiter:
+    limit_mib: "400"
+    spike_limit_mib: "100"
+    check_interval: "5s"


### PR DESCRIPTION
Special request from the API team: https://packet.atlassian.net/browse/ENG-21642

Tested locally by generating Helm template output, worked great.