### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-* @equinixmetal/governor-metal-sre
-


### PR DESCRIPTION
As we move toward having this be a "community-owned" chart within Metal, I think it makes the most sense to allow anyone within the equinixmetal-helm org approve PRs here. The alternative would be to make a separate "OTel" group within the org and add a few people who have a good understanding of the chart. I don't think it's necessary to have a separate group to maintain, especially since PRs require approval anyway to be merged.