### PR TITLE
Release v0.5.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-otel-collector
 description: OpenTelemetry Collector Helm Chart
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.42.0"  # OpenTelemetry Collector build version
 dependencies:
   - name: common


### PR DESCRIPTION
There's probably a nice way to automate creating the tag or something but we'll do it like this for now. Once I push the tag, [the release GitHub action](https://github.com/equinixmetal-helm/k8s-otel-collector/blob/main/.github/workflows/release.yaml) will automatically publish the package at helm.equinixmetal.com.