### PR TITLE
Remove spanmetrics processor

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -18,11 +18,6 @@ data:
               scrape_interval: 15s
               static_configs:
                 - targets: ["127.0.0.1:8888"]
-      # Dummy receiver that's never used, because a pipeline is required to have one.
-      otlp/spanmetrics:
-        protocols:
-          grpc:
-            endpoint: "localhost:12345"
 
     processors:
       batch:
@@ -36,8 +31,6 @@ data:
         - key: service.group
           value: "equinix-metal"
           action: insert
-      spanmetrics:
-        metrics_exporter: prometheus
 
     exporters:
       otlp:
@@ -50,8 +43,6 @@ data:
           "x-honeycomb-team": "${HONEYCOMB_ENV_API_KEY}"
           # dataset is required for metrics data
           "x-honeycomb-dataset": "collector-metrics"
-      prometheus:
-        endpoint: 0.0.0.0:8889
 
     extensions:
       health_check:
@@ -64,12 +55,9 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, resource, batch, spanmetrics]
+          processors: [memory_limiter, resource, batch]
           exporters: [otlp]
         metrics:
           receivers: [prometheus]
           processors: [resource]
-          exporters: [otlp/metrics,prometheus]
-        metrics/spanmetrics:
-          receivers: [otlp/spanmetrics]
-          exporters: [prometheus]
+          exporters: [otlp/metrics]


### PR DESCRIPTION
The spanmetrics processor has been deprecated in favor of the [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md), so we'll try that out soon.