### PR TITLE
ENG-22361: Allow disabling memory ballast

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -63,12 +63,13 @@ data:
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
-      zpages:
+      zpages:{{ if .Values.memory_ballast.enabled }}
       memory_ballast:
-        size_mib: 683
+        size_mib: {{ .Values.memory_ballast.size_mib }}{{ end }}
 
-    service:
-      extensions: [memory_ballast, health_check, zpages]
+    service:{{ if .Values.memory_ballast.enabled }}
+      extensions: [memory_ballast, health_check, zpages]{{ else }}
+      extensions: [health_check, zpages]{{ end }}
       pipelines:
         traces:
           receivers: [otlp]

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,10 @@ memory_limiter:
   spike_limit_mib: "100"
   check_interval: "5s"
 
+memory_ballast:
+  enabled: true
+  size_mib: 683
+
 # override in downstream parent chart to deploy ServiceMonitor
 # allows Prometheus Operator to scrape metrics
 servicemonitor:


### PR DESCRIPTION
Leaving it enabled by default so there's no behavior change for now. In the future we might decide to remove it entirely. See https://github.com/open-telemetry/opentelemetry-collector/issues/7512#issuecomment-1653971324

Also added a variable so we can override the ballast size if desired.