### PR TITLE
[ENG-22440] Replace spanmetrics connector with optional exporter

### DIFF
--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -47,11 +47,11 @@ data:
           "x-honeycomb-team": "${HONEYCOMB_ENV_API_KEY}"
           # dataset is required for metrics data
           "x-honeycomb-dataset": "collector-metrics"
-      {{- if .Values.spanmetrics_exporter.enabled }}
-      otlp/spanmetrics:
-        endpoint: {{ .Values.spanmetrics_exporter.endpoint }}
+      {{- if .Values.addl_traces_exporter.enabled }}
+      {{ .Values.addl_traces_exporter.name }}:
+        endpoint: {{ .Values.addl_traces_exporter.endpoint }}
         tls:
-          insecure: true
+          {{ .Values.addl_traces_exporter.tls }}
       {{- end }}
 
     extensions:
@@ -73,8 +73,8 @@ data:
         traces:
           receivers:  [otlp]
           processors: [memory_limiter, resource, batch]
-          {{- if .Values.spanmetrics_exporter.enabled }}
-          exporters:  [otlp/traces-honeycomb, otlp/spanmetrics]
+          {{- if .Values.addl_traces_exporter.enabled }}
+          exporters:  [otlp/traces-honeycomb, {{ .Values.addl_traces_exporter.name }}]
           {{- else }}
           exporters:  [otlp/traces-honeycomb]
           {{- end }}

--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -5,7 +5,6 @@ metadata:
 data:
   opentelemetry-collector-config: |
 
-
     receivers:
       otlp:  # can receive all data formats
         protocols:
@@ -29,7 +28,10 @@ data:
         spike_limit_mib: {{ .Values.memory_limiter.spike_limit_mib }}
         check_interval:  {{ .Values.memory_limiter.check_interval }}
       resource:
-        attributes:{{ if .Values.include_otel_attributes }}{{- include "otel_attributes" . | indent 8 }}{{ end }}
+        attributes:
+        {{- if .Values.include_otel_attributes }}
+        {{- include "otel_attributes" . | indent 8 }}
+        {{- end }}
         - key: service.group
           value: "equinix-metal"
           action: insert
@@ -45,26 +47,37 @@ data:
           "x-honeycomb-team": "${HONEYCOMB_ENV_API_KEY}"
           # dataset is required for metrics data
           "x-honeycomb-dataset": "collector-metrics"
-      {{ if .Values.traces_pipeline.spanmetrics_exporter }}otlp/spanmetrics:
-        endpoint: otel-spanmetrics:4317
+      {{- if .Values.spanmetrics_exporter.enabled }}
+      otlp/spanmetrics:
+        endpoint: {{ .Values.spanmetrics_exporter.endpoint }}
         tls:
-          insecure: true{{ end }}
+          insecure: true
+      {{- end }}
 
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
-      zpages:{{ if .Values.memory_ballast.enabled }}
+      zpages:
+      {{- if .Values.memory_ballast.enabled }}
       memory_ballast:
-        size_mib: {{ .Values.memory_ballast.size_mib }}{{ end }}
+        size_mib: {{ .Values.memory_ballast.size_mib }}
+      {{- end }}
 
-    service:{{ if .Values.memory_ballast.enabled }}
-      extensions: [memory_ballast, health_check, zpages]{{ else }}
-      extensions: [health_check, zpages]{{ end }}
+    service:
+    {{- if .Values.memory_ballast.enabled }}
+      extensions: [memory_ballast, health_check, zpages]
+      {{- else }}
+      extensions: [health_check, zpages]
+      {{- end }}
       pipelines:
         traces:
           receivers:  [otlp]
           processors: [memory_limiter, resource, batch]
-          {{ if .Values.traces_pipeline.spanmetrics_exporter }}exporters:  [otlp/traces-honeycomb, otlp/spanmetrics]{{ else }}exporters:  [otlp/traces-honeycomb]{{ end }}
+          {{- if .Values.spanmetrics_exporter.enabled }}
+          exporters:  [otlp/traces-honeycomb, otlp/spanmetrics]
+          {{- else }}
+          exporters:  [otlp/traces-honeycomb]
+          {{- end }}
         metrics/collector-metrics:
           receivers:  [prometheus/collector-metrics]
           processors: [memory_limiter, resource, batch]

--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -43,22 +43,6 @@ data:
           "x-honeycomb-team": "${HONEYCOMB_ENV_API_KEY}"
           # dataset is required for metrics data
           "x-honeycomb-dataset": "collector-metrics"
-      prometheus/spanmetrics:
-        endpoint: "0.0.0.0:9090"
-
-    connectors:
-      spanmetrics:
-        histogram:
-          explicit:
-            buckets: [2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]
-        dimensions:
-          - name: http.method
-            default: GET
-          - name: http.status_code
-        exclude_dimensions: ['status.code']
-        dimensions_cache_size: 1000
-        aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"    
-        metrics_flush_interval: 15s
 
     extensions:
       health_check:
@@ -74,12 +58,8 @@ data:
         traces:
           receivers:  [otlp]
           processors: [memory_limiter, resource, batch]
-          exporters:  [otlp/traces-honeycomb, spanmetrics]
+          exporters:  [otlp/traces-honeycomb]
         metrics/collector-metrics:
           receivers:  [prometheus/collector-metrics]
           processors: [memory_limiter, resource, batch]
           exporters:  [otlp/collector-metrics-honeycomb]
-        metrics/spanmetrics:
-          receivers:  [spanmetrics]
-          processors: [memory_limiter, batch]
-          exporters:  [prometheus/spanmetrics]

--- a/templates/opentelemetry-collector-config.yaml
+++ b/templates/opentelemetry-collector-config.yaml
@@ -4,6 +4,8 @@ metadata:
   name: opentelemetry-collector
 data:
   opentelemetry-collector-config: |
+
+
     receivers:
       otlp:  # can receive all data formats
         protocols:
@@ -43,6 +45,10 @@ data:
           "x-honeycomb-team": "${HONEYCOMB_ENV_API_KEY}"
           # dataset is required for metrics data
           "x-honeycomb-dataset": "collector-metrics"
+      {{ if .Values.traces_pipeline.spanmetrics_exporter }}otlp/spanmetrics:
+        endpoint: otel-spanmetrics:4317
+        tls:
+          insecure: true{{ end }}
 
     extensions:
       health_check:
@@ -58,7 +64,7 @@ data:
         traces:
           receivers:  [otlp]
           processors: [memory_limiter, resource, batch]
-          exporters:  [otlp/traces-honeycomb]
+          {{ if .Values.traces_pipeline.spanmetrics_exporter }}exporters:  [otlp/traces-honeycomb, otlp/spanmetrics]{{ else }}exporters:  [otlp/traces-honeycomb]{{ end }}
         metrics/collector-metrics:
           receivers:  [prometheus/collector-metrics]
           processors: [memory_limiter, resource, batch]

--- a/values.yaml
+++ b/values.yaml
@@ -19,10 +19,10 @@ memory_ballast:
 
 # allow exporting to an additional collector or tracing backend
 addl_traces_exporter:
-  enabled: true
-  name: otlp/spanmetrics
-  endpoint: spanmetrics-collector:4317
-  tls: "insecure: true"
+  enabled: false
+  # name: otlp/spanmetrics
+  # endpoint: spanmetrics-collector:4317
+  # tls: "insecure: true"
 
 # override in downstream parent chart to deploy ServiceMonitor
 # allows Prometheus Operator to scrape metrics

--- a/values.yaml
+++ b/values.yaml
@@ -17,8 +17,9 @@ memory_ballast:
   enabled: true
   size_mib: 683
 
-traces_pipeline:
-  spanmetrics_exporter: true # false by default
+spanmetrics_exporter:
+  enabled: false
+  # endpoint: spanmetrics-collector:4317
 
 # override in downstream parent chart to deploy ServiceMonitor
 # allows Prometheus Operator to scrape metrics

--- a/values.yaml
+++ b/values.yaml
@@ -17,9 +17,12 @@ memory_ballast:
   enabled: true
   size_mib: 683
 
-spanmetrics_exporter:
-  enabled: false
-  # endpoint: spanmetrics-collector:4317
+# allow exporting to an additional collector or tracing backend
+addl_traces_exporter:
+  enabled: true
+  name: otlp/spanmetrics
+  endpoint: spanmetrics-collector:4317
+  tls: "insecure: true"
 
 # override in downstream parent chart to deploy ServiceMonitor
 # allows Prometheus Operator to scrape metrics

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,9 @@ memory_ballast:
   enabled: true
   size_mib: 683
 
+traces_pipeline:
+  spanmetrics_exporter: true # false by default
+
 # override in downstream parent chart to deploy ServiceMonitor
 # allows Prometheus Operator to scrape metrics
 servicemonitor:


### PR DESCRIPTION
This will allow downstream services to route to a local spanmetrics-specific collector (see https://github.com/equinixmetal/k8s-central-api/pull/1270).

**This is a breaking change. Services currently using spanmetrics will need to deploy a separate collector to handle that processing.** I believe at this point only the API service is using spanmetrics, which is already handled in the PR I linked.

For now I'm just enabling a single additional exporter. In the future we might make it possible to add multiple, but the templating was starting to get hairy so I decided to stop here.

I also cleaned up some of the templating so it handles whitespace better.