### PR TITLE
Remove remaining spanmetrics references

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
             - name: otlp-grpc
               containerPort: 4317
               protocol: TCP
-            - name: prometheus-exp
-              containerPort: 8889
-              protocol: TCP
           volumeMounts:
             - name: opentelemetry-collector-config
               mountPath: /conf

--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -11,8 +11,6 @@ spec:
     matchLabels:
       k8s-app: opentelemetry-collector
   endpoints:
-  - port: prometheus-collector-metrics
-    interval: 15s
-  - port: prometheus-spanmetrics
+  - port: collector-metrics
     interval: 15s
 {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -22,11 +22,7 @@ spec:
     port: 55681
     protocol: TCP
     targetPort: otlp-http
-  - name: prometheus-collector-metrics
+  - name: collector-metrics
     port: 8888
     protocol: TCP
     targetPort: 8888
-  - name: prometheus-spanmetrics
-    port: 9090
-    protocol: TCP
-    targetPort: 9090


### PR DESCRIPTION
Also rename "prometheus-collector-metrics" to "collector-metrics" because the prometheus part is redundant in our actual monitoring.